### PR TITLE
fix occasional fails of playing Stone.wav

### DIFF
--- a/src/main/java/featurecat/lizzie/util/Utils.java
+++ b/src/main/java/featurecat/lizzie/util/Utils.java
@@ -836,7 +836,7 @@ public class Utils {
       sourceDataLine.start();
       // Read from the data sent to the mixer input stream
       int count;
-      byte tempBuffer[] = new byte[1024];
+      byte tempBuffer[] = new byte[8192];
       while ((count = audioInputStream.read(tempBuffer, 0, tempBuffer.length)) != -1) {
         if (count > 0) {
           sourceDataLine.write(tempBuffer, 0, count);


### PR DESCRIPTION
Seems the size of `tempBuffer` is too small, which cause the issue I posted in #201 
Tested, it works well.