### PR TITLE
Fix UI scaling problems when moving window between different DPI display

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/LizzieFrame.java
@@ -1574,6 +1574,40 @@ public class LizzieFrame extends JFrame {
     mainPanel.setVisible(false);
     commentScrollPane.setVisible(false);
     blunderContentPane.setVisible(false);
+    // Listen for GraphicsConfiguration changes (e.g. moving window between monitors with different
+    // DPI). When detected, update javaScaleFactor / Config.isScaled and trigger layout/refresh.
+    this.addPropertyChangeListener(
+        "graphicsConfiguration",
+        evt -> {
+          try {
+            java.awt.GraphicsConfiguration graphicsConfig =
+                (java.awt.GraphicsConfiguration) evt.getNewValue();
+            if (graphicsConfig == null) {
+              return;
+            }
+            final AffineTransform tx = graphicsConfig.getDefaultTransform();
+            final double scaling = tx.getScaleX();
+            boolean wasScaled = Config.isScaled;
+            float oldJavaScale = Lizzie.javaScaleFactor;
+            if (scaling > 1.0) {
+              Config.isScaled = true;
+              Lizzie.javaScaleFactor = (float) scaling;
+            } else {
+              Config.isScaled = false;
+              Lizzie.javaScaleFactor = 1.0f;
+            }
+            if (Math.abs(Lizzie.javaScaleFactor - oldJavaScale) > 0.001f
+                || wasScaled != Config.isScaled) {
+              // reposition and redraw UI to account for new scaling
+              reSetLoc();
+              refreshContainer();
+              repaint();
+            }
+          } catch (Exception ex) {
+            ex.printStackTrace();
+          }
+        });
+
     setVisible(true);
   }
 


### PR DESCRIPTION
### Problem:
On a dual-monitor setup with a Full HD display and a 4K display, the UI layout breaks when displaying lizzieyzy on the 4K monitor.

<img width="1579" height="1041" alt="image" src="https://github.com/user-attachments/assets/3c1b7724-3499-42eb-bd4e-8ee82710ea47" />

### What this PR does:
Adds a graphicsConfiguration PropertyChangeListener to the LizzieFrame constructor.
When the window is moved between monitors and the GraphicsConfiguration changes, it updates Config.isScaled and Lizzie.javaScaleFactor, then repositions and repaints the UI accordingly.

### Cause:
This issue does not occur in 2.5.1 and starts appearing from 2.5.2 onward.

Since 2.5.2, there are two coexisting behaviors:
* On startup, AwareScaled.java reads Graphics2D.getDefaultTransform() and sets the application-side scaling.
* On rendering, several places (Utils.java, LizzieFrame.java, Lizzie.java, Config.java) both apply inverse transforms to Graphics and use javaScaleFactor for manual scaling.

In certain environments, this combination can result in inconsistent or double-applied scaling, which leads to layout breakage on HiDPI displays.

### Verification:

mvn package succeeds.
On a Full HD / 4K dual-monitor setup, confirmed that moving the window between monitors no longer breaks the UI layout.

