### PR TITLE
fix hawkeye first column header both white

### DIFF
--- a/src/main/java/featurecat/lizzie/gui/MoveListFrame.java
+++ b/src/main/java/featurecat/lizzie/gui/MoveListFrame.java
@@ -1310,10 +1310,15 @@ public class MoveListFrame extends JFrame {
     minTable1.getTableHeader().setReorderingAllowed(false);
     minTable2.getTableHeader().setReorderingAllowed(false);
 
-    TableCellRenderer hr = headerMint1.getDefaultRenderer();
-    ((JLabel) hr).setHorizontalAlignment(JLabel.CENTER);
-    headerMint1.setDefaultRenderer(hr);
-    headerMint2.setDefaultRenderer(hr);
+    TableCellRenderer hr1 = headerMint1.getDefaultRenderer();
+    if (hr1 instanceof JLabel) {
+      ((JLabel) hr1).setHorizontalAlignment(JLabel.CENTER);
+    }
+
+    TableCellRenderer hr2 = headerMint2.getDefaultRenderer();
+    if (hr2 instanceof JLabel) {
+      ((JLabel) hr2).setHorizontalAlignment(JLabel.CENTER);
+    }
 
     checkBlack.setSelected(true);
     checkWhite.setSelected(true);


### PR DESCRIPTION
PR description
==============

In the HawkEye view, the first column header of the two tables
should be **Black** (left) and **White** (right), but both headers are shown as **White**.

<img width="1093" height="732" alt="issue" src="https://github.com/user-attachments/assets/b4109148-16f3-4d04-8fd4-3b8e455d2a52" />

This happens because both `JTableHeader`s share the same stateful
`TableCellRenderer` instance. On Windows with the System LookAndFeel, the
header text from the second table bleeds into the first one.

This patch stops sharing the renderer between the two headers and instead uses
each header’s own default renderer, only adjusting the alignment when it is a
`JLabel`. This removes the unintended coupling and restores the expected
`Black` / `White` headers.


How to reproduce
================

1. Build the shaded JAR:

   mvn package

2. On Windows, run:

   java -jar target/lizzie-yzy2.5.3-shaded.jar

3. In the initial settings dialog, select **System LookAndFeel**.
4. Open **HawkEye**.
5. Observe that both first column headers are labeled **White** instead of **Black** / **White**.